### PR TITLE
add net_attr argument to networkLite edgelist constructor

### DIFF
--- a/R/constructors.R
+++ b/R/constructors.R
@@ -72,8 +72,8 @@ networkLite <- function(x, ...) {
 #' @export
 networkLite.edgelist <- function(
     x,
-    attr = list(vertex.names = seq_len(attributes(x)[["n"]]),
-                na = logical(attributes(x)[["n"]])),
+    attr = list(vertex.names = seq_len(net_attr[["n"]]),
+                na = logical(net_attr[["n"]])),
     net_attr = attributes(x)[setdiff(names(attributes(x)),
                                          c("class", "dim", "dimnames",
                                            "vnames", "row.names", "names",

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -5,30 +5,25 @@
 #'
 #' @description Constructor methods for `networkLite` objects.
 #'
-#' @param x Either an `edgelist` class network representation, including
-#'        network attributes as `attr`-style attributes on the
-#'        `edgelist`, or a number specifying the network size. The
-#'        `edgelist` may be either a `tibble` or a `matrix`. If
-#'        a `tibble` is passed, it should have integer columns named
-#'        `".tail"` and `".head"` for the tails and heads of edges,
+#' @param x Either an `edgelist` class network representation, or a number
+#'        specifying the network size. The `edgelist` may be either a `tibble`
+#'        or a `matrix`. If a `tibble` is passed, it should have integer columns
+#'        named `".tail"` and `".head"` for the tails and heads of edges,
 #'        and may include edge attributes as additional columns. If a
 #'        `matrix` is passed, it should have two columns, the first being
 #'        the tails of edges and the second being the heads of edges; edge
 #'        attributes are not supported for `matrix` arguments. Edges
 #'        should be sorted, first on tails then on heads. See
 #'        [`network::as.edgelist`] for information on producing such
-#'        `edgelist` objects from `network` objects. The `edgelist`
-#'        *must* have the `"n"` attribute
-#'        indicating the network size, and may include additional named
-#'        `attr`-style attributes that will be interpreted as network
-#'        attributes and copied to the `networkLite`. Exceptions to this
-#'        are attributes named `"class"`, `"dim"`, `"dimnames"`,
-#'        `"vnames"`, `"row.names"`, `"names"`, and
-#'        `"mnext"`; these are not copied from the `edgelist` to the
-#'        `networkLite`.
+#'        `edgelist` objects from `network` objects.
 #' @param attr A named list of vertex attributes, coerced to `tibble`.
 #'        Each element of `attr` should be an atomic vector or list of
 #'        length equal to the number of nodes in the network.
+#' @param net_attr A named list of network attributes. Must include the network
+#'        size attribute named `"n"`. Defaults to a subset of the `attr`-style
+#'        attributes of `x` for backwards compatibility; it is recommended that
+#'        new code specify `net_attr` explicitly rather than relying on this
+#'        default.
 #' @param directed,bipartite Common network attributes that may be set via
 #'        arguments to the `networkLite.numeric` method.
 #' @param atomize Logical; should we call [`atomize`] on the
@@ -40,16 +35,12 @@
 #' @details Currently there are several distinct `networkLite` constructor
 #' methods available.
 #'
-#' The `edgelist` method takes an `edgelist` class object `x`
-#' with network attributes attached in its `attributes` list, and a named
-#' list of vertex attributes `attr`, and returns a `networkLite`
-#' object, which is a named list with fields `el`, `attr`, and
-#' `gal`. The fields `el` and `attr` are `tibble`s
-#' corresponding to the `x` and `attr` arguments, respectively, and
-#' the field `gal` is the list of network attributes (copied from
-#' `attributes(x)`, with the exceptions noted above). Missing network
-#' attributes `directed` and `bipartite` are defaulted to
-#' `FALSE`; the network size attribute `n` must not be missing.
+#' The `edgelist` method takes an `edgelist` class object `x`, a named
+#' list of vertex attributes `attr`, and a named list of network attributes
+#' `net_attr`, and returns a `networkLite` object, which is a named list with
+#' fields `el`, `attr`, and `gal`, corresponding to the arguments `x`, `attr`,
+#' and `net_attr`. Missing network attributes `directed` and `bipartite` are
+#' defaulted to `FALSE`; the network size attribute `n` must not be missing.
 #'
 #' The `numeric` method takes a number `x` as well as the network
 #' attributes `directed` and `bipartite` (defaulting to `FALSE`),
@@ -83,6 +74,10 @@ networkLite.edgelist <- function(
     x,
     attr = list(vertex.names = seq_len(attributes(x)[["n"]]),
                 na = logical(attributes(x)[["n"]])),
+    net_attr = attributes(x)[setdiff(names(attributes(x)),
+                                         c("class", "dim", "dimnames",
+                                           "vnames", "row.names", "names",
+                                           "mnext"))],
     ...,
     atomize = FALSE) {
 
@@ -101,10 +96,7 @@ networkLite.edgelist <- function(
 
   nw <- list(el = el,
              attr = as_tibble(attr),
-             gal = attributes(x)[setdiff(names(attributes(x)),
-                                         c("class", "dim", "dimnames",
-                                           "vnames", "row.names", "names",
-                                           "mnext"))])
+             gal = net_attr)
 
   if ("na" %in% names(nw$el)) {
     if (is.logical(nw$el[["na"]])) {

--- a/man/constructors.Rd
+++ b/man/constructors.Rd
@@ -14,6 +14,8 @@ networkLite(x, ...)
   x,
   attr = list(vertex.names = seq_len(attributes(x)[["n"]]), na =
     logical(attributes(x)[["n"]])),
+  net_attr = attributes(x)[setdiff(names(attributes(x)), c("class", "dim", "dimnames",
+    "vnames", "row.names", "names", "mnext"))],
   ...,
   atomize = FALSE
 )
@@ -22,6 +24,8 @@ networkLite(x, ...)
   x,
   attr = list(vertex.names = seq_len(attributes(x)[["n"]]), na =
     logical(attributes(x)[["n"]])),
+  net_attr = attributes(x)[setdiff(names(attributes(x)), c("class", "dim", "dimnames",
+    "vnames", "row.names", "names", "mnext"))],
   ...,
   atomize = FALSE
 )
@@ -31,33 +35,29 @@ networkLite(x, ...)
 networkLite_initialize(x, directed = FALSE, bipartite = FALSE, ...)
 }
 \arguments{
-\item{x}{Either an \code{edgelist} class network representation, including
-network attributes as \code{attr}-style attributes on the
-\code{edgelist}, or a number specifying the network size. The
-\code{edgelist} may be either a \code{tibble} or a \code{matrix}. If
-a \code{tibble} is passed, it should have integer columns named
-\code{".tail"} and \code{".head"} for the tails and heads of edges,
+\item{x}{Either an \code{edgelist} class network representation, or a number
+specifying the network size. The \code{edgelist} may be either a \code{tibble}
+or a \code{matrix}. If a \code{tibble} is passed, it should have integer columns
+named \code{".tail"} and \code{".head"} for the tails and heads of edges,
 and may include edge attributes as additional columns. If a
 \code{matrix} is passed, it should have two columns, the first being
 the tails of edges and the second being the heads of edges; edge
 attributes are not supported for \code{matrix} arguments. Edges
 should be sorted, first on tails then on heads. See
 \code{\link[network:as.edgelist]{network::as.edgelist}} for information on producing such
-\code{edgelist} objects from \code{network} objects. The \code{edgelist}
-\emph{must} have the \code{"n"} attribute
-indicating the network size, and may include additional named
-\code{attr}-style attributes that will be interpreted as network
-attributes and copied to the \code{networkLite}. Exceptions to this
-are attributes named \code{"class"}, \code{"dim"}, \code{"dimnames"},
-\code{"vnames"}, \code{"row.names"}, \code{"names"}, and
-\code{"mnext"}; these are not copied from the \code{edgelist} to the
-\code{networkLite}.}
+\code{edgelist} objects from \code{network} objects.}
 
 \item{...}{additional arguments}
 
 \item{attr}{A named list of vertex attributes, coerced to \code{tibble}.
 Each element of \code{attr} should be an atomic vector or list of
 length equal to the number of nodes in the network.}
+
+\item{net_attr}{A named list of network attributes. Must include the network
+size attribute named \code{"n"}. Defaults to a subset of the \code{attr}-style
+attributes of \code{x} for backwards compatibility; it is recommended that
+new code specify \code{net_attr} explicitly rather than relying on this
+default.}
 
 \item{atomize}{Logical; should we call \code{\link{atomize}} on the
 \code{networkLite} before returning it? Note that unlike
@@ -76,16 +76,12 @@ Constructor methods for \code{networkLite} objects.
 Currently there are several distinct \code{networkLite} constructor
 methods available.
 
-The \code{edgelist} method takes an \code{edgelist} class object \code{x}
-with network attributes attached in its \code{attributes} list, and a named
-list of vertex attributes \code{attr}, and returns a \code{networkLite}
-object, which is a named list with fields \code{el}, \code{attr}, and
-\code{gal}. The fields \code{el} and \code{attr} are \code{tibble}s
-corresponding to the \code{x} and \code{attr} arguments, respectively, and
-the field \code{gal} is the list of network attributes (copied from
-\code{attributes(x)}, with the exceptions noted above). Missing network
-attributes \code{directed} and \code{bipartite} are defaulted to
-\code{FALSE}; the network size attribute \code{n} must not be missing.
+The \code{edgelist} method takes an \code{edgelist} class object \code{x}, a named
+list of vertex attributes \code{attr}, and a named list of network attributes
+\code{net_attr}, and returns a \code{networkLite} object, which is a named list with
+fields \code{el}, \code{attr}, and \code{gal}, corresponding to the arguments \code{x}, \code{attr},
+and \code{net_attr}. Missing network attributes \code{directed} and \code{bipartite} are
+defaulted to \code{FALSE}; the network size attribute \code{n} must not be missing.
 
 The \code{numeric} method takes a number \code{x} as well as the network
 attributes \code{directed} and \code{bipartite} (defaulting to \code{FALSE}),

--- a/man/constructors.Rd
+++ b/man/constructors.Rd
@@ -12,8 +12,7 @@ networkLite(x, ...)
 
 \method{networkLite}{edgelist}(
   x,
-  attr = list(vertex.names = seq_len(attributes(x)[["n"]]), na =
-    logical(attributes(x)[["n"]])),
+  attr = list(vertex.names = seq_len(net_attr[["n"]]), na = logical(net_attr[["n"]])),
   net_attr = attributes(x)[setdiff(names(attributes(x)), c("class", "dim", "dimnames",
     "vnames", "row.names", "names", "mnext"))],
   ...,
@@ -22,8 +21,7 @@ networkLite(x, ...)
 
 \method{networkLite}{matrix}(
   x,
-  attr = list(vertex.names = seq_len(attributes(x)[["n"]]), na =
-    logical(attributes(x)[["n"]])),
+  attr = list(vertex.names = seq_len(net_attr[["n"]]), na = logical(net_attr[["n"]])),
   net_attr = attributes(x)[setdiff(names(attributes(x)), c("class", "dim", "dimnames",
     "vnames", "row.names", "names", "mnext"))],
   ...,

--- a/tests/testthat/test-networkLite.R
+++ b/tests/testthat/test-networkLite.R
@@ -100,7 +100,7 @@ test_that("net_attr overrides attributes(x)", {
   nw[3,7] <- 1
   el <- as.edgelist(nw)
   expect_error(nwL <- networkLite(el, net_attr = list(newattr = "val")),
-               "`n` attribute")
+               "non-negative integer")
   nwL <- networkLite(el, net_attr = list(n = 10, newattr = "val"))
   expect_equal(network.size(nwL), 10)
   expect_equal(get.network.attribute(nwL, "newattr"), "val")

--- a/tests/testthat/test-networkLite.R
+++ b/tests/testthat/test-networkLite.R
@@ -95,6 +95,17 @@ create_random_edgelist <- function(n_nodes, directed, bipartite, target_n_edges)
   structure(el, n = n_nodes, directed = directed, bipartite = bipartite)
 }
 
+test_that("net_attr overrides attributes(x)", {
+  nw <- network.initialize(10, directed = FALSE)
+  nw[3,7] <- 1
+  el <- as.edgelist(nw)
+  expect_error(nwL <- networkLite(el, net_attr = list(newattr = "val")),
+               "`n` attribute")
+  nwL <- networkLite(el, net_attr = list(n = 10, newattr = "val"))
+  expect_equal(network.size(nwL), 10)
+  expect_equal(get.network.attribute(nwL, "newattr"), "val")
+})
+
 test_that("%e%<- behaves as expected", {
   net_size <- 100
   bip_size <- 40


### PR DESCRIPTION
references EpiModel/EpiModel#801

Passing network attributes as a separate argument is generally preferable to using a subset of `attributes(x)` as the latter commingles network attributes and other attributes.